### PR TITLE
Issue9: Used ThreadPoolExecutor instead of normal threads. This seeme…

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ They do not have to be installed separately.
 ## Setup and Installation
 
 The current installation instructions are manual, but will soon be replaced by proper packages that will allow easy installation of RxROS2.
-RxROS2 is originally developed and tested of the Eloquent Elusor platform, but we have not been able to provide proper installation instructions for this platform (see [issue 2](https://github.com/rosin-project/rxros2/issues/2) for a discussion of the problem).
-Foxy Fitzroy has therefore become the preferred platform for RxROS2 although we have observed a serious issue with `rclpy` / RxROS2 for this platform (see [issue 9](https://github.com/rosin-project/rxros9/issues/2)).
 
 Installation of `rosdep` (this will resolve our dependencies):
 

--- a/rxros2_py/rxros2/__init__.py
+++ b/rxros2_py/rxros2/__init__.py
@@ -23,6 +23,7 @@ from rx.operators import *
 from rx.disposable import Disposable
 from rclpy.node import Node as ROS2Node
 from rclpy.action import ActionClient, ActionServer
+from concurrent.futures import ThreadPoolExecutor
 
 
 class Node(ROS2Node):
@@ -35,13 +36,14 @@ class Node(ROS2Node):
         :param node_name: The name of the node.
         """
         super().__init__(node_name)
+        self.myExecutor = ThreadPoolExecutor(max_workers=1)
 
     @abstractmethod
     def run(self):
         pass
 
     def start(self):
-        threading.Thread(target=self.run).start()
+        self.myExecutor.submit(self.run())
 
 
 def create_node(node_name: str) -> ROS2Node:


### PR DESCRIPTION
Solved issue #9 by using a ThreadPoolExecutor with one worker instead of a "normal" Thread. This solved the problem, or more precisely it has not been possible to reproduce the problem using the ThreadPoolExecutor. Several tests have been performed on several platforms including PCs (amd64 arch) and Raspberry Pi 4 (arm arch).